### PR TITLE
fix: Prevent the language to be forced on the transcript endpoint

### DIFF
--- a/src/Transcriptions.php
+++ b/src/Transcriptions.php
@@ -112,15 +112,21 @@ class Transcriptions
                 'name' => 'model',
                 'contents' => $params['model'] ?? 'whisper-large-v3'
             ],
-            [
-                'name' => 'temperature',
-                'contents' => $params['temperature'] ?? 0.0
-            ],
-            [
-                'name' => 'language',
-                'contents' => $params['language'] ?? 'en'
-            ]
         ];
+
+        if (isset($params['temperature'])) {
+            $multipart[] = [
+                'name' => 'temperature',
+                'contents' => $params['temperature']
+            ];
+        }
+
+        if (isset($params['language'])) {
+            $multipart[] = [
+                'name' => 'language',
+                'contents' => $params['language']
+            ];
+        }
 
         if (isset($params['prompt'])) {
             $multipart[] = [


### PR DESCRIPTION
The whisper model is able to detect the language automatically when the parameter is not provided.

Therefore, we should not force the `language` on the API payload.  

Otherwise, for the following piece of code : 

```php
$response = Groq::audio()->transcriptions()->create([
    'file' => '/path/to/file',
    'model' => 'whisper-large-v3',
]);
```

The payload will look like this : 

```
file => '...'
model => '...'
temperature => 0.0
language => 'en'
```

And so whisper won't try to auto detect the language, because it is defaulted to English.